### PR TITLE
git tag で紐づくコミットを github.sha ではなく作業ブランチの最新コミットにする

### DIFF
--- a/.github/workflows/tag_push.yml
+++ b/.github/workflows/tag_push.yml
@@ -25,7 +25,8 @@ jobs:
           release_datetime=$(date +'%Y%m%d-%H%M')
           echo "new_release_tag=v$release_datetime" >> $GITHUB_OUTPUT
       - run: |
-          git show --format='%H' --no-patch
+          git show
+          git show ${{ github.event.pull_request.head.sha }}
           git tag ${{ steps.release_date.outputs.new_release_tag }}
           git show ${{ steps.release_date.outputs.new_release_tag }}
           git push origin ${{ steps.release_date.outputs.new_release_tag }}

--- a/.github/workflows/tag_push.yml
+++ b/.github/workflows/tag_push.yml
@@ -27,6 +27,7 @@ jobs:
       - run: |
           git show
           git show ${{ github.event.pull_request.head.sha }}
+          git show ${{ github.sha }}
           git tag ${{ steps.release_date.outputs.new_release_tag }}
           git show ${{ steps.release_date.outputs.new_release_tag }}
           git push origin ${{ steps.release_date.outputs.new_release_tag }}

--- a/.github/workflows/tag_push.yml
+++ b/.github/workflows/tag_push.yml
@@ -25,9 +25,6 @@ jobs:
           release_datetime=$(date +'%Y%m%d-%H%M')
           echo "new_release_tag=v$release_datetime" >> $GITHUB_OUTPUT
       - run: |
-          git show
-          git show ${{ github.event.pull_request.head.sha }}
-          git show ${{ github.sha }}
-          git tag ${{ steps.release_date.outputs.new_release_tag }}
+          git tag ${{ steps.release_date.outputs.new_release_tag }} ${{ github.event.pull_request.head.sha }}
           git show ${{ steps.release_date.outputs.new_release_tag }}
           git push origin ${{ steps.release_date.outputs.new_release_tag }}

--- a/.github/workflows/tag_push.yml
+++ b/.github/workflows/tag_push.yml
@@ -25,5 +25,6 @@ jobs:
           release_datetime=$(date +'%Y%m%d-%H%M')
           echo "new_release_tag=v$release_datetime" >> $GITHUB_OUTPUT
       - run: |
+          git show --format='%H' --no-patch
           git tag ${{ steps.release_date.outputs.new_release_tag }}
           git push origin ${{ steps.release_date.outputs.new_release_tag }}

--- a/.github/workflows/tag_push.yml
+++ b/.github/workflows/tag_push.yml
@@ -27,4 +27,5 @@ jobs:
       - run: |
           git show --format='%H' --no-patch
           git tag ${{ steps.release_date.outputs.new_release_tag }}
+          git show ${{ steps.release_date.outputs.new_release_tag }}
           git push origin ${{ steps.release_date.outputs.new_release_tag }}


### PR DESCRIPTION
# やりたいこと
- git tag で紐づくコミットが変な感じになってるので実験する